### PR TITLE
Revert "feat: add chat_status to mentor_application"

### DIFF
--- a/metadata/tables.yaml
+++ b/metadata/tables.yaml
@@ -1865,26 +1865,13 @@
       permission:
         check: {}
         columns:
-          - chat_status
-          - created_at
-          - id
           - mentor_id
           - statement
           - status
           - student_id
-          - updated_at
-    - role: root
-      permission:
-        check: {}
-        columns:
-          - chat_status
           - created_at
-          - id
-          - mentor_id
-          - statement
-          - status
-          - student_id
           - updated_at
+          - id
     - role: student
       permission:
         check:
@@ -1898,33 +1885,30 @@
     - role: counselor
       permission:
         columns:
-          - chat_status
-          - created_at
           - id
-          - mentor_id
-          - statement
-          - status
-          - student_id
+          - created_at
           - updated_at
+          - statement
+          - mentor_id
+          - student_id
+          - status
         filter: {}
         allow_aggregations: true
     - role: root
       permission:
         columns:
-          - chat_status
-          - created_at
-          - id
           - mentor_id
           - statement
           - status
           - student_id
+          - created_at
           - updated_at
+          - id
         filter: {}
         allow_aggregations: true
     - role: student
       permission:
         columns:
-          - chat_status
           - created_at
           - id
           - mentor_id
@@ -1937,14 +1921,13 @@
     - role: teacher
       permission:
         columns:
-          - chat_status
-          - created_at
           - id
-          - mentor_id
-          - statement
-          - status
-          - student_id
+          - created_at
           - updated_at
+          - statement
+          - mentor_id
+          - student_id
+          - status
         filter:
           mentor_id:
             _eq: X-Hasura-User-Id
@@ -1964,33 +1947,18 @@
     - role: root
       permission:
         columns:
-          - chat_status
-          - created_at
-          - id
           - mentor_id
           - statement
           - status
           - student_id
-          - updated_at
-        filter: {}
-        check: {}
-    - role: root
-      permission:
-        columns:
-          - chat_status
           - created_at
-          - id
-          - mentor_id
-          - statement
-          - status
-          - student_id
           - updated_at
+          - id
         filter: {}
         check: {}
     - role: student
       permission:
         columns:
-          - chat_status
           - statement
         filter:
           student_id:

--- a/migrations/1692688454069_alter_table_public_mentor_application_add_column_chat_status/down.sql
+++ b/migrations/1692688454069_alter_table_public_mentor_application_add_column_chat_status/down.sql
@@ -1,4 +1,0 @@
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."mentor_application" add column "chat_status" boolean
---  not null default '0';

--- a/migrations/1692688454069_alter_table_public_mentor_application_add_column_chat_status/up.sql
+++ b/migrations/1692688454069_alter_table_public_mentor_application_add_column_chat_status/up.sql
@@ -1,2 +1,0 @@
-alter table "public"."mentor_application" add column "chat_status" boolean
- not null default '0';


### PR DESCRIPTION
之前直接在生产环境控制台改了，执行migrations时报chat_status已存在。
解决方式是不修改仓库了，直接手动同步（开发和生产执行同样的操作）。