### PR TITLE
feat(users): add a column id

### DIFF
--- a/metadata/tables.yaml
+++ b/metadata/tables.yaml
@@ -2943,6 +2943,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role
@@ -2962,6 +2963,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role
@@ -2981,6 +2983,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role
@@ -3000,6 +3003,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role
@@ -3020,6 +3024,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role
@@ -3040,6 +3045,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role
@@ -3060,6 +3066,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role
@@ -3080,6 +3087,7 @@
           - department
           - email
           - github_id
+          - id
           - phone
           - realname
           - role

--- a/migrations/1700494048710_alter_table_public_users_add_column_id/down.sql
+++ b/migrations/1700494048710_alter_table_public_users_add_column_id/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."users" add column "id" text
+--  null unique;

--- a/migrations/1700494048710_alter_table_public_users_add_column_id/up.sql
+++ b/migrations/1700494048710_alter_table_public_users_add_column_id/up.sql
@@ -1,0 +1,2 @@
+alter table "public"."users" add column "id" text
+ null unique;

--- a/migrations/1700494068642_alter_table_public_users_alter_column_role/down.sql
+++ b/migrations/1700494068642_alter_table_public_users_alter_column_role/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" alter column "role" set default 'user'::text;

--- a/migrations/1700494068642_alter_table_public_users_alter_column_role/up.sql
+++ b/migrations/1700494068642_alter_table_public_users_alter_column_role/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" alter column "role" set default 'anonymous';


### PR DESCRIPTION
由于mongodb的id生成和hasura的uuid不一样，所以新建一列id用于用户数据迁移。
现在暂时的生成方式是，新用户先插入自动生成uuid，然后令id=uuid。老用户直接使用原id。功能仍绑定到id上。
后面应将功能迁移到uuid上并将id删除。