### PR TITLE
fix: team_label nullable

### DIFF
--- a/migrations/1711103008359_alter_table_public_contest_room_team_add_column_team_label/down.sql
+++ b/migrations/1711103008359_alter_table_public_contest_room_team_add_column_team_label/down.sql
@@ -1,4 +1,3 @@
 -- Could not auto-generate a down migration.
 -- Please write an appropriate down migration for the SQL below:
 -- alter table "public"."contest_room_team" add column "team_label" text
---  not null;

--- a/migrations/1711103008359_alter_table_public_contest_room_team_add_column_team_label/up.sql
+++ b/migrations/1711103008359_alter_table_public_contest_room_team_add_column_team_label/up.sql
@@ -1,2 +1,1 @@
-alter table "public"."contest_room_team" add column "team_label" text
- not null;
+alter table "public"."contest_room_team" add column "team_label" text;

--- a/migrations/1711293040453_alter_table_public_contest_room_team_alter_column_team_label/down.sql
+++ b/migrations/1711293040453_alter_table_public_contest_room_team_alter_column_team_label/down.sql
@@ -1,1 +1,0 @@
-alter table "public"."contest_room_team" alter column "team_label" set not null;

--- a/migrations/1711293040453_alter_table_public_contest_room_team_alter_column_team_label/up.sql
+++ b/migrations/1711293040453_alter_table_public_contest_room_team_alter_column_team_label/up.sql
@@ -1,1 +1,0 @@
-alter table "public"."contest_room_team" alter column "team_label" drop not null;


### PR DESCRIPTION
尝试直接修改了一下up.sql文件
GPT knowledge:
在Hasura Migrations中，up.sql 和 down.sql 是用于描述数据库架构更改的SQL文件。

up.sql 文件：这个文件包含了应用某个特定迁移所需要的SQL命令。例如，如果你的迁移是用于添加一个新的表，那么 up.sql 文件就会包含创建那个新表的SQL命令。

down.sql 文件：这个文件包含了撤销 up.sql 中更改的SQL命令。它是 up.sql 的反操作。例如，如果 up.sql 是用于创建一个新的表，那么 down.sql 就应该包含删除那个新表的SQL命令。

Hasura Migrations使用这两个文件来确保数据库架构的更改可以被准确地应用和撤销。当你运行一个迁移时，Hasura会执行 up.sql 中的命令。如果你需要撤销那个迁移，Hasura则会执行 down.sql 中的命令。